### PR TITLE
feat: Add isEligible field to age range result types

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,12 +88,14 @@ import {
 } from 'react-native-play-age-range-declaration';
 
 type PlayAgeSignalsResult = {
+  isEligible: boolean; // true if the user is in a region where age verification is legally required
   installId?: string;
   userStatus?: string; // https://developer.android.com/google/play/age-signals/use-age-signals-api
   error?: string;
 };
 
 type DeclaredAgeRangeResult = {
+  isEligible: boolean; // true if the device supports age features and the API is available
   status?: string;
   parentControls?: string; // selfDeclared | guardianDeclared
   lowerBound?: number;
@@ -158,6 +160,7 @@ export default function App() {
         <ScrollView style={styles.resultBox}>
           {Platform.OS === 'ios' ? (
             <Text style={styles.resultText}>
+              Is Eligible: {appleResult ? String(appleResult?.isEligible) : ''} {`\n`}
               Status: {appleResult ? appleResult?.status : ''} {`\n`}
               ParentControls: {appleResult
                 ? appleResult?.parentControls
@@ -167,6 +170,7 @@ export default function App() {
             </Text>
           ) : (
             <Text style={styles.resultText}>
+              Is Eligible: {androidResult ? String(androidResult?.isEligible) : ''} {`\n`}
               Install Id: {androidResult ? androidResult?.installId : ''} {`\n`}
               User Status: {androidResult ? androidResult?.userStatus : ''}{' '}
               {`\n`}
@@ -247,6 +251,15 @@ const styles = StyleSheet.create({
   },
 });
 ```
+
+---
+
+## 🔍 Understanding `isEligible`
+
+Both result types include an `isEligible` boolean field that indicates whether age-related features are available and applicable for the current user:
+
+- **`true`**: The user is in a region where age verification is legally required.
+- **`false`**: The user is not in an applicable region, if isEligible is false we should be allow to let users view age gated content *(Not verified by a laywer)*
 
 ---
 

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -15,12 +15,14 @@ import {
 } from 'react-native-play-age-range-declaration';
 
 type PlayAgeSignalsResult = {
+  isEligible: boolean;
   installId?: string;
   userStatus?: string;
   error?: string;
 };
 
 type DeclaredAgeRangeResult = {
+  isEligible: boolean;
   status?: string;
   parentControls?: string;
   lowerBound?: number;
@@ -85,6 +87,8 @@ export default function App() {
         <ScrollView style={styles.resultBox}>
           {Platform.OS === 'ios' ? (
             <Text style={styles.resultText}>
+              Is Eligible: {appleResult ? String(appleResult?.isEligible) : ''}{' '}
+              {`\n`}
               Status: {appleResult ? appleResult?.status : ''} {`\n`}
               ParentControls: {appleResult
                 ? appleResult?.parentControls
@@ -94,8 +98,12 @@ export default function App() {
             </Text>
           ) : (
             <Text style={styles.resultText}>
+              Is Eligible:{' '}
+              {androidResult ? String(androidResult?.isEligible) : ''} {`\n`}
               Install Id: {androidResult ? androidResult?.installId : ''} {`\n`}
               User Status: {androidResult ? androidResult?.userStatus : ''}{' '}
+              {'\n'}
+              Error: {androidResult ? androidResult?.error : ''} {`\n`}
               {`\n`}
             </Text>
           )}

--- a/nitrogen/generated/android/c++/JDeclaredAgeRangeResult.hpp
+++ b/nitrogen/generated/android/c++/JDeclaredAgeRangeResult.hpp
@@ -32,6 +32,8 @@ namespace margelo::nitro::playagerangedeclaration {
     [[nodiscard]]
     DeclaredAgeRangeResult toCpp() const {
       static const auto clazz = javaClassStatic();
+      static const auto fieldIsEligible = clazz->getField<jboolean>("isEligible");
+      jboolean isEligible = this->getFieldValue(fieldIsEligible);
       static const auto fieldStatus = clazz->getField<jni::JString>("status");
       jni::local_ref<jni::JString> status = this->getFieldValue(fieldStatus);
       static const auto fieldParentControls = clazz->getField<jni::JString>("parentControls");
@@ -41,6 +43,7 @@ namespace margelo::nitro::playagerangedeclaration {
       static const auto fieldUpperBound = clazz->getField<jni::JDouble>("upperBound");
       jni::local_ref<jni::JDouble> upperBound = this->getFieldValue(fieldUpperBound);
       return DeclaredAgeRangeResult(
+        static_cast<bool>(isEligible),
         status != nullptr ? std::make_optional(status->toStdString()) : std::nullopt,
         parentControls != nullptr ? std::make_optional(parentControls->toStdString()) : std::nullopt,
         lowerBound != nullptr ? std::make_optional(lowerBound->value()) : std::nullopt,
@@ -54,11 +57,12 @@ namespace margelo::nitro::playagerangedeclaration {
      */
     [[maybe_unused]]
     static jni::local_ref<JDeclaredAgeRangeResult::javaobject> fromCpp(const DeclaredAgeRangeResult& value) {
-      using JSignature = JDeclaredAgeRangeResult(jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JDouble>);
+      using JSignature = JDeclaredAgeRangeResult(jboolean, jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>, jni::alias_ref<jni::JDouble>, jni::alias_ref<jni::JDouble>);
       static const auto clazz = javaClassStatic();
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(
         clazz,
+        value.isEligible,
         value.status.has_value() ? jni::make_jstring(value.status.value()) : nullptr,
         value.parentControls.has_value() ? jni::make_jstring(value.parentControls.value()) : nullptr,
         value.lowerBound.has_value() ? jni::JDouble::valueOf(value.lowerBound.value()) : nullptr,

--- a/nitrogen/generated/android/c++/JPlayAgeRangeDeclarationResult.hpp
+++ b/nitrogen/generated/android/c++/JPlayAgeRangeDeclarationResult.hpp
@@ -32,6 +32,8 @@ namespace margelo::nitro::playagerangedeclaration {
     [[nodiscard]]
     PlayAgeRangeDeclarationResult toCpp() const {
       static const auto clazz = javaClassStatic();
+      static const auto fieldIsEligible = clazz->getField<jboolean>("isEligible");
+      jboolean isEligible = this->getFieldValue(fieldIsEligible);
       static const auto fieldInstallId = clazz->getField<jni::JString>("installId");
       jni::local_ref<jni::JString> installId = this->getFieldValue(fieldInstallId);
       static const auto fieldUserStatus = clazz->getField<jni::JString>("userStatus");
@@ -39,6 +41,7 @@ namespace margelo::nitro::playagerangedeclaration {
       static const auto fieldError = clazz->getField<jni::JString>("error");
       jni::local_ref<jni::JString> error = this->getFieldValue(fieldError);
       return PlayAgeRangeDeclarationResult(
+        static_cast<bool>(isEligible),
         installId != nullptr ? std::make_optional(installId->toStdString()) : std::nullopt,
         userStatus != nullptr ? std::make_optional(userStatus->toStdString()) : std::nullopt,
         error != nullptr ? std::make_optional(error->toStdString()) : std::nullopt
@@ -51,11 +54,12 @@ namespace margelo::nitro::playagerangedeclaration {
      */
     [[maybe_unused]]
     static jni::local_ref<JPlayAgeRangeDeclarationResult::javaobject> fromCpp(const PlayAgeRangeDeclarationResult& value) {
-      using JSignature = JPlayAgeRangeDeclarationResult(jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>);
+      using JSignature = JPlayAgeRangeDeclarationResult(jboolean, jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>, jni::alias_ref<jni::JString>);
       static const auto clazz = javaClassStatic();
       static const auto create = clazz->getStaticMethod<JSignature>("fromCpp");
       return create(
         clazz,
+        value.isEligible,
         value.installId.has_value() ? jni::make_jstring(value.installId.value()) : nullptr,
         value.userStatus.has_value() ? jni::make_jstring(value.userStatus.value()) : nullptr,
         value.error.has_value() ? jni::make_jstring(value.error.value()) : nullptr

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/playagerangedeclaration/DeclaredAgeRangeResult.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/playagerangedeclaration/DeclaredAgeRangeResult.kt
@@ -19,6 +19,9 @@ import com.facebook.proguard.annotations.DoNotStrip
 data class DeclaredAgeRangeResult(
   @DoNotStrip
   @Keep
+  val isEligible: Boolean,
+  @DoNotStrip
+  @Keep
   val status: String?,
   @DoNotStrip
   @Keep
@@ -40,8 +43,8 @@ data class DeclaredAgeRangeResult(
     @Keep
     @Suppress("unused")
     @JvmStatic
-    private fun fromCpp(status: String?, parentControls: String?, lowerBound: Double?, upperBound: Double?): DeclaredAgeRangeResult {
-      return DeclaredAgeRangeResult(status, parentControls, lowerBound, upperBound)
+    private fun fromCpp(isEligible: Boolean, status: String?, parentControls: String?, lowerBound: Double?, upperBound: Double?): DeclaredAgeRangeResult {
+      return DeclaredAgeRangeResult(isEligible, status, parentControls, lowerBound, upperBound)
     }
   }
 }

--- a/nitrogen/generated/android/kotlin/com/margelo/nitro/playagerangedeclaration/PlayAgeRangeDeclarationResult.kt
+++ b/nitrogen/generated/android/kotlin/com/margelo/nitro/playagerangedeclaration/PlayAgeRangeDeclarationResult.kt
@@ -19,6 +19,9 @@ import com.facebook.proguard.annotations.DoNotStrip
 data class PlayAgeRangeDeclarationResult(
   @DoNotStrip
   @Keep
+  val isEligible: Boolean,
+  @DoNotStrip
+  @Keep
   val installId: String?,
   @DoNotStrip
   @Keep
@@ -37,8 +40,8 @@ data class PlayAgeRangeDeclarationResult(
     @Keep
     @Suppress("unused")
     @JvmStatic
-    private fun fromCpp(installId: String?, userStatus: String?, error: String?): PlayAgeRangeDeclarationResult {
-      return PlayAgeRangeDeclarationResult(installId, userStatus, error)
+    private fun fromCpp(isEligible: Boolean, installId: String?, userStatus: String?, error: String?): PlayAgeRangeDeclarationResult {
+      return PlayAgeRangeDeclarationResult(isEligible, installId, userStatus, error)
     }
   }
 }

--- a/nitrogen/generated/ios/swift/DeclaredAgeRangeResult.swift
+++ b/nitrogen/generated/ios/swift/DeclaredAgeRangeResult.swift
@@ -19,8 +19,8 @@ public extension DeclaredAgeRangeResult {
   /**
    * Create a new instance of `DeclaredAgeRangeResult`.
    */
-  init(status: String?, parentControls: String?, lowerBound: Double?, upperBound: Double?) {
-    self.init({ () -> bridge.std__optional_std__string_ in
+  init(isEligible: Bool, status: String?, parentControls: String?, lowerBound: Double?, upperBound: Double?) {
+    self.init(isEligible, { () -> bridge.std__optional_std__string_ in
       if let __unwrappedValue = status {
         return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
       } else {
@@ -47,6 +47,17 @@ public extension DeclaredAgeRangeResult {
     }())
   }
 
+  var isEligible: Bool {
+    @inline(__always)
+    get {
+      return self.__isEligible
+    }
+    @inline(__always)
+    set {
+      self.__isEligible = newValue
+    }
+  }
+  
   var status: String? {
     @inline(__always)
     get {

--- a/nitrogen/generated/ios/swift/PlayAgeRangeDeclarationResult.swift
+++ b/nitrogen/generated/ios/swift/PlayAgeRangeDeclarationResult.swift
@@ -19,8 +19,8 @@ public extension PlayAgeRangeDeclarationResult {
   /**
    * Create a new instance of `PlayAgeRangeDeclarationResult`.
    */
-  init(installId: String?, userStatus: String?, error: String?) {
-    self.init({ () -> bridge.std__optional_std__string_ in
+  init(isEligible: Bool, installId: String?, userStatus: String?, error: String?) {
+    self.init(isEligible, { () -> bridge.std__optional_std__string_ in
       if let __unwrappedValue = installId {
         return bridge.create_std__optional_std__string_(std.string(__unwrappedValue))
       } else {
@@ -41,6 +41,17 @@ public extension PlayAgeRangeDeclarationResult {
     }())
   }
 
+  var isEligible: Bool {
+    @inline(__always)
+    get {
+      return self.__isEligible
+    }
+    @inline(__always)
+    set {
+      self.__isEligible = newValue
+    }
+  }
+  
   var installId: String? {
     @inline(__always)
     get {

--- a/nitrogen/generated/shared/c++/DeclaredAgeRangeResult.hpp
+++ b/nitrogen/generated/shared/c++/DeclaredAgeRangeResult.hpp
@@ -35,6 +35,7 @@ namespace margelo::nitro::playagerangedeclaration {
    */
   struct DeclaredAgeRangeResult {
   public:
+    bool isEligible     SWIFT_PRIVATE;
     std::optional<std::string> status     SWIFT_PRIVATE;
     std::optional<std::string> parentControls     SWIFT_PRIVATE;
     std::optional<double> lowerBound     SWIFT_PRIVATE;
@@ -42,7 +43,7 @@ namespace margelo::nitro::playagerangedeclaration {
 
   public:
     DeclaredAgeRangeResult() = default;
-    explicit DeclaredAgeRangeResult(std::optional<std::string> status, std::optional<std::string> parentControls, std::optional<double> lowerBound, std::optional<double> upperBound): status(status), parentControls(parentControls), lowerBound(lowerBound), upperBound(upperBound) {}
+    explicit DeclaredAgeRangeResult(bool isEligible, std::optional<std::string> status, std::optional<std::string> parentControls, std::optional<double> lowerBound, std::optional<double> upperBound): isEligible(isEligible), status(status), parentControls(parentControls), lowerBound(lowerBound), upperBound(upperBound) {}
   };
 
 } // namespace margelo::nitro::playagerangedeclaration
@@ -55,6 +56,7 @@ namespace margelo::nitro {
     static inline margelo::nitro::playagerangedeclaration::DeclaredAgeRangeResult fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
       jsi::Object obj = arg.asObject(runtime);
       return margelo::nitro::playagerangedeclaration::DeclaredAgeRangeResult(
+        JSIConverter<bool>::fromJSI(runtime, obj.getProperty(runtime, "isEligible")),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, "status")),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, "parentControls")),
         JSIConverter<std::optional<double>>::fromJSI(runtime, obj.getProperty(runtime, "lowerBound")),
@@ -63,6 +65,7 @@ namespace margelo::nitro {
     }
     static inline jsi::Value toJSI(jsi::Runtime& runtime, const margelo::nitro::playagerangedeclaration::DeclaredAgeRangeResult& arg) {
       jsi::Object obj(runtime);
+      obj.setProperty(runtime, "isEligible", JSIConverter<bool>::toJSI(runtime, arg.isEligible));
       obj.setProperty(runtime, "status", JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.status));
       obj.setProperty(runtime, "parentControls", JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.parentControls));
       obj.setProperty(runtime, "lowerBound", JSIConverter<std::optional<double>>::toJSI(runtime, arg.lowerBound));
@@ -77,6 +80,7 @@ namespace margelo::nitro {
       if (!nitro::isPlainObject(runtime, obj)) {
         return false;
       }
+      if (!JSIConverter<bool>::canConvert(runtime, obj.getProperty(runtime, "isEligible"))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, "status"))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, "parentControls"))) return false;
       if (!JSIConverter<std::optional<double>>::canConvert(runtime, obj.getProperty(runtime, "lowerBound"))) return false;

--- a/nitrogen/generated/shared/c++/PlayAgeRangeDeclarationResult.hpp
+++ b/nitrogen/generated/shared/c++/PlayAgeRangeDeclarationResult.hpp
@@ -35,13 +35,14 @@ namespace margelo::nitro::playagerangedeclaration {
    */
   struct PlayAgeRangeDeclarationResult {
   public:
+    bool isEligible     SWIFT_PRIVATE;
     std::optional<std::string> installId     SWIFT_PRIVATE;
     std::optional<std::string> userStatus     SWIFT_PRIVATE;
     std::optional<std::string> error     SWIFT_PRIVATE;
 
   public:
     PlayAgeRangeDeclarationResult() = default;
-    explicit PlayAgeRangeDeclarationResult(std::optional<std::string> installId, std::optional<std::string> userStatus, std::optional<std::string> error): installId(installId), userStatus(userStatus), error(error) {}
+    explicit PlayAgeRangeDeclarationResult(bool isEligible, std::optional<std::string> installId, std::optional<std::string> userStatus, std::optional<std::string> error): isEligible(isEligible), installId(installId), userStatus(userStatus), error(error) {}
   };
 
 } // namespace margelo::nitro::playagerangedeclaration
@@ -54,6 +55,7 @@ namespace margelo::nitro {
     static inline margelo::nitro::playagerangedeclaration::PlayAgeRangeDeclarationResult fromJSI(jsi::Runtime& runtime, const jsi::Value& arg) {
       jsi::Object obj = arg.asObject(runtime);
       return margelo::nitro::playagerangedeclaration::PlayAgeRangeDeclarationResult(
+        JSIConverter<bool>::fromJSI(runtime, obj.getProperty(runtime, "isEligible")),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, "installId")),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, "userStatus")),
         JSIConverter<std::optional<std::string>>::fromJSI(runtime, obj.getProperty(runtime, "error"))
@@ -61,6 +63,7 @@ namespace margelo::nitro {
     }
     static inline jsi::Value toJSI(jsi::Runtime& runtime, const margelo::nitro::playagerangedeclaration::PlayAgeRangeDeclarationResult& arg) {
       jsi::Object obj(runtime);
+      obj.setProperty(runtime, "isEligible", JSIConverter<bool>::toJSI(runtime, arg.isEligible));
       obj.setProperty(runtime, "installId", JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.installId));
       obj.setProperty(runtime, "userStatus", JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.userStatus));
       obj.setProperty(runtime, "error", JSIConverter<std::optional<std::string>>::toJSI(runtime, arg.error));
@@ -74,6 +77,7 @@ namespace margelo::nitro {
       if (!nitro::isPlainObject(runtime, obj)) {
         return false;
       }
+      if (!JSIConverter<bool>::canConvert(runtime, obj.getProperty(runtime, "isEligible"))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, "installId"))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, "userStatus"))) return false;
       if (!JSIConverter<std::optional<std::string>>::canConvert(runtime, obj.getProperty(runtime, "error"))) return false;

--- a/src/PlayAgeRangeDeclaration.nitro.ts
+++ b/src/PlayAgeRangeDeclaration.nitro.ts
@@ -1,12 +1,14 @@
 import type { HybridObject } from 'react-native-nitro-modules';
 
 export interface PlayAgeRangeDeclarationResult {
+  isEligible: boolean;
   installId?: string;
   userStatus?: string;
   error?: string;
 }
 
 export interface DeclaredAgeRangeResult {
+  isEligible: boolean;
   status?: string;
   parentControls?: string;
   lowerBound?: number;


### PR DESCRIPTION
This PR adds a new isEligible boolean field to both PlayAgeRangeDeclarationResult (Android) and DeclaredAgeRangeResult (iOS) to help developers determine whether age verification APIs are available and applicable for the current user/device.

The intent here is to have a field for when it is safe to let users view age gated content without verifying their age. I may change the isEligible status on different error states when I learn anything new legally


I tested this on an iOS and Android simulator. I was unable to test on real devices so was only able to verify isEligible is false when not implemented or not available 