### PR TITLE
[Proposal] Shared API for Android and iOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ Android: No extra configuration needed, but for this API to work, you have to ha
 
 ## ⚙️ Usage
 
+### Basic Usage
+
 ```tsx
 import { useState } from 'react';
 import {
@@ -177,6 +179,157 @@ export default function App() {
 
       <Pressable style={styles.button} onPress={fetchStatus}>
         <Text style={styles.buttonTitle}>Check</Text>
+      </Pressable>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    padding: 20,
+    backgroundColor: '#f4f6f8',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  header: {
+    fontSize: 20,
+    fontWeight: '700',
+    marginBottom: 20,
+  },
+  resultBox: {
+    maxHeight: 240,
+    width: '100%',
+    backgroundColor: '#fff',
+    borderRadius: 10,
+    padding: 12,
+    shadowColor: '#000',
+    shadowOpacity: 0.1,
+    shadowOffset: { width: 0, height: 2 },
+    shadowRadius: 6,
+    elevation: 2,
+  },
+  resultText: {
+    fontFamily: Platform.select({ ios: 'Menlo', android: 'monospace' }),
+    fontSize: 13,
+    color: '#333',
+  },
+
+  button: {
+    backgroundColor: '#2fe5e5',
+    borderRadius: 10,
+    padding: 12,
+    width: '100%',
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 20,
+  },
+
+  buttonTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: 'black',
+  },
+
+  errorBox: {
+    backgroundColor: '#ffe5e5',
+    borderRadius: 10,
+    padding: 12,
+    width: '100%',
+  },
+  errorTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#b00020',
+    marginBottom: 4,
+  },
+  errorText: {
+    color: '#b00020',
+    fontSize: 14,
+  },
+});
+```
+
+### Using `getIsOlderThan` with Singleton Pattern
+
+**App Configuration (index.js or App.tsx):**
+
+```tsx
+import { setAgeRangeThresholds } from 'react-native-play-age-range-declaration';
+
+// Configure age range thresholds once when the app initializes
+// Must be between 1-18, ascending order, no duplicates, 1-3 values
+try {
+  setAgeRangeThresholds([10, 13, 16]);
+} catch (err) {
+  console.error('Failed to set age range thresholds:', err);
+}
+```
+
+**Component Usage:**
+
+```tsx
+import { useState } from 'react';
+import {
+  Text,
+  View,
+  StyleSheet,
+  ActivityIndicator,
+  ScrollView,
+  Platform,
+  Pressable,
+} from 'react-native';
+
+import { getIsOlderThan } from 'react-native-play-age-range-declaration';
+
+export default function App() {
+  const [isOlderThanResult, setIsOlderThanResult] = useState<boolean | null>(
+    null
+  );
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const checkAge = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      // Check if user is older than a specific age
+      const isOlderThan18 = await getIsOlderThan(18);
+      setIsOlderThanResult(isOlderThan18);
+    } catch (err: any) {
+      console.error('❌ Failed to check age:', err);
+      const msg =
+        err?.message ??
+        err?.nativeStackAndroid ??
+        'Unknown error checking age';
+      setError(msg);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      <Text style={styles.header}>Age Range Declaration Demo</Text>
+
+      {loading ? (
+        <ActivityIndicator size="large" color="#007aff" />
+      ) : error ? (
+        <View style={styles.errorBox}>
+          <Text style={styles.errorTitle}>Error</Text>
+          <Text style={styles.errorText}>{error}</Text>
+        </View>
+      ) : (
+        <ScrollView style={styles.resultBox}>
+          <Text style={styles.resultText}>
+            Is older than 18: {isOlderThanResult !== null ? (isOlderThanResult ? 'Yes' : 'No') : 'Not checked'}
+          </Text>
+        </ScrollView>
+      )}
+
+      <Pressable style={styles.button} onPress={checkAge}>
+        <Text style={styles.buttonTitle}>Check Age</Text>
       </Pressable>
     </View>
   );

--- a/src/AgeRangeThresholdManager.ts
+++ b/src/AgeRangeThresholdManager.ts
@@ -1,0 +1,60 @@
+class AgeRangeThresholdManager {
+  private static instance: AgeRangeThresholdManager;
+  private thresholds: number[] | null = null;
+
+  private constructor() {}
+
+  static getInstance(): AgeRangeThresholdManager {
+    if (!AgeRangeThresholdManager.instance) {
+      AgeRangeThresholdManager.instance = new AgeRangeThresholdManager();
+    }
+    return AgeRangeThresholdManager.instance;
+  }
+
+  setAgeRangeThresholds(thresholds: number[]): void {
+    if (thresholds.length < 1 || thresholds.length > 3) {
+      throw new Error(
+        'PlayAgeRangeDeclaration: Age range thresholds must contain at least 1 and at most 3 values'
+      );
+    }
+
+    if (!thresholds.every((t) => Number.isInteger(t))) {
+      throw new Error('PlayAgeRangeDeclaration: All age range thresholds must be integers');
+    }
+
+    // Validate: minimum value is 1, maximum value is 18
+    if (thresholds.some((t) => t < 1 || t > 18)) {
+      throw new Error(
+        'PlayAgeRangeDeclaration: setAgeRangeThresholds: Age range thresholds must be between 1 and 18 (inclusive)'
+      );
+    }
+
+    // Validate: ascending order
+    for (let i = 1; i < thresholds.length; i++) {
+      const current = thresholds[i];
+      const previous = thresholds[i - 1];
+      if (current !== undefined && previous !== undefined && current <= previous) {
+        throw new Error(
+          'PlayAgeRangeDeclaration: Age range thresholds must be in ascending order'
+        );
+      }
+    }
+
+    // Validate: no duplicates (already covered by ascending order check, but explicit check for clarity)
+    const uniqueThresholds = new Set(thresholds);
+    if (uniqueThresholds.size !== thresholds.length) {
+      throw new Error('PlayAgeRangeDeclaration: Age range thresholds must not contain duplicates');
+    }
+
+    this.thresholds = [...thresholds];
+  }
+
+  getThresholds(): number[] {
+    if (this.thresholds === null) {
+      throw new Error('PlayAgeRangeDeclaration: ageRangeThresholds not set');
+    }
+    return [...this.thresholds];
+  }
+}
+
+export const ageRangeThresholdManager = AgeRangeThresholdManager.getInstance();

--- a/src/PlayAgeRangeDeclaration.nitro.ts
+++ b/src/PlayAgeRangeDeclaration.nitro.ts
@@ -1,5 +1,12 @@
 import type { HybridObject } from 'react-native-nitro-modules';
 
+export interface CommonAgeRangeResult {
+  isEligible: boolean;
+  lowerAgeBound?: number;
+  upperAgeBound?: number;
+  hasParentControls?: boolean;
+}
+
 export interface PlayAgeRangeDeclarationResult {
   installId?: string;
   userStatus?: string;
@@ -15,6 +22,11 @@ export interface DeclaredAgeRangeResult {
 
 export interface PlayAgeRangeDeclaration
   extends HybridObject<{ ios: 'swift'; android: 'kotlin' }> {
+  setAgeRangeThresholds(
+    firstThresholdAge: number,
+    secondThresholdAge: number,
+    thirdThresholdAge: number
+  ): Promise<void>;
   getPlayAgeRangeDeclaration(): Promise<PlayAgeRangeDeclarationResult>;
   requestDeclaredAgeRange(
     firstThresholdAge: number,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,21 +1,33 @@
 import { NitroModules } from 'react-native-nitro-modules';
+import { Platform } from 'react-native';
 
 import type {
   DeclaredAgeRangeResult,
   PlayAgeRangeDeclaration,
   PlayAgeRangeDeclarationResult,
+  CommonAgeRangeResult,
 } from './PlayAgeRangeDeclaration.nitro';
+
+import { ageRangeThresholdManager } from './AgeRangeThresholdManager';
 
 const PlayAgeRangeDeclarationHybridObject =
   NitroModules.createHybridObject<PlayAgeRangeDeclaration>(
     'PlayAgeRangeDeclaration'
   );
 
-export async function getAppleDeclaredAgeRangeStatus(
-  firstThresholdAge: number,
-  secondThresholdAge: number,
-  thirdThresholdAge: number
-): Promise<DeclaredAgeRangeResult> {
+export function setAgeRangeThresholds(thresholds: number[]): void {
+  ageRangeThresholdManager.setAgeRangeThresholds(thresholds);
+}
+
+export async function getAppleDeclaredAgeRangeStatus(): Promise<DeclaredAgeRangeResult> {
+  const thresholds = ageRangeThresholdManager.getThresholds();
+  
+  // Pad to 3 values (the API expects 3 parameters)
+  const firstThresholdAge = thresholds[0] ?? 1;
+  const secondThresholdAge = thresholds[1] ?? thresholds[0] ?? 1;
+  const lastThreshold = thresholds[thresholds.length - 1] ?? 1;
+  const thirdThresholdAge = thresholds[2] ?? lastThreshold;
+
   return await PlayAgeRangeDeclarationHybridObject.requestDeclaredAgeRange(
     firstThresholdAge,
     secondThresholdAge,
@@ -25,4 +37,27 @@ export async function getAppleDeclaredAgeRangeStatus(
 
 export async function getAndroidPlayAgeRangeStatus(): Promise<PlayAgeRangeDeclarationResult> {
   return await PlayAgeRangeDeclarationHybridObject.getPlayAgeRangeDeclaration();
+}
+
+export async function getAgeRangeStatus(): Promise<CommonAgeRangeResult> {
+  if (Platform.OS === 'android') {
+    const result = await getAndroidPlayAgeRangeStatus();
+    return {
+      isEligible: result.isEligible,
+      lowerAgeBound: result.lowerAgeBound,
+      upperAgeBound: result.upperAgeBound,
+    };
+  } else {
+    const result = await getAppleDeclaredAgeRangeStatus();
+    return {
+      isEligible: result.status === 'eligible',
+      lowerAgeBound: result.lowerBound,
+      upperAgeBound: result.upperBound,
+    };
+  }
+  //... convert to CommonAgeRangeResult
+}
+
+export async function getIsOlderThan(age: number): Promise<boolean> {
+  return true
 }


### PR DESCRIPTION
Just a draft to see if it is something you would consider. Open to all changes and feel free to reject the whole thing. If you like it I'll work on making a real PR


This refactors the API to use a singleton pattern for age thresholds. And makes a getCommonAgeRangeResult that can be used for both iOS and Android. 

`setAgeRangeThresholds` must be called **once during app initialization** (not in components). This is important because Apple doesn't want you to change thresholds after calling once - otherwise apps could triangulate a user's exact age by calling the API multiple times with different thresholds.

I'm assuming most users will only need `getIsOlderThan(age)` where `age` is one of the thresholds you set initially.

**Example:**
```typescript
// In index.js or App.tsx (app initialization)
setAgeRangeThresholds([13, 15, 18]);

// Later in your app
const isOlderThan18 = await getIsOlderThan(18);
```