### PR TITLE
feat: enable isEligibleForAgeFeatures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,7 +119,7 @@ jobs:
     runs-on: macos-latest
 
     env:
-      XCODE_VERSION: 16.3
+      XCODE_VERSION: 26.2
       TURBO_CACHE_DIR: .turbo/ios
       RCT_USE_RN_DEP: 1
       RCT_USE_PREBUILT_RNCORE: 1

--- a/ios/PlayAgeRangeDeclaration.swift
+++ b/ios/PlayAgeRangeDeclaration.swift
@@ -16,16 +16,16 @@ class PlayAgeRangeDeclaration: HybridPlayAgeRangeDeclarationSpec {
         }
 
         // You can comment out this guard if you want to test this in a region where you are not legally required to show the age verification prompt
-        // guard AgeRangeService.shared.isEligibleForAgeFeatures else {
-        //   let message = "Declared Age Range API is not available on this device"
-        //     return DeclaredAgeRangeResult(
-        //       isEligible: false,
-        //       status: nil,
-        //       parentControls: nil,
-        //       lowerBound: nil,
-        //       upperBound: nil
-        //     )
-        // }
+        guard AgeRangeService.shared.isEligibleForAgeFeatures else {
+          let message = "Declared Age Range API is not available on this device"
+            return DeclaredAgeRangeResult(
+              isEligible: false,
+              status: nil,
+              parentControls: nil,
+              lowerBound: nil,
+              upperBound: nil
+            )
+        }
 
         guard let viewController = Self.topViewController() else {
           let message = "Could not find top view controller to present UI"


### PR DESCRIPTION
This change reenables the isEligibleForAgeFeatures.

This is required to ensure you are in a region where we are required to show the age verification prompt. 

This only is available on Xcode 26.2 which came out of beta on Friday. Not sure if any CI needs to be updated to support this