### PR TITLE
feat: Simplify android age mocking

### DIFF
--- a/android/src/main/java/com/margelo/nitro/playagerangedeclaration/PlayAgeRangeMockConfig.kt
+++ b/android/src/main/java/com/margelo/nitro/playagerangedeclaration/PlayAgeRangeMockConfig.kt
@@ -1,0 +1,15 @@
+package com.margelo.nitro.playagerangedeclaration
+
+import com.google.android.play.agesignals.model.AgeSignalsVerificationStatus
+import java.util.Date
+
+data class PlayAgeRangeMockConfig(
+  // Required fields
+  @AgeSignalsVerificationStatus val userStatus: Int,
+
+  // Optional fields
+  val ageLower: Int? = null,
+  val ageUpper: Int? = null,
+  val installId: String? = null,
+  val mostRecentApprovalDate: Date? = null,
+)

--- a/src/PlayAgeRangeDeclaration.nitro.ts
+++ b/src/PlayAgeRangeDeclaration.nitro.ts
@@ -8,6 +8,7 @@ export const PlayAgeRangeDeclarationUserStatus = {
   UNKNOWN: '4',
 } as const;
 
+// https://developer.android.com/google/play/age-signals/use-age-signals-api#age-signals-responses
 export const PlayAgeRangeDeclarationUserStatusString: Record<string, string> = {
   [PlayAgeRangeDeclarationUserStatus.VERIFIED]: 'VERIFIED',
   [PlayAgeRangeDeclarationUserStatus.SUPERVISED]: 'SUPERVISED',
@@ -18,19 +19,41 @@ export const PlayAgeRangeDeclarationUserStatusString: Record<string, string> = {
   [PlayAgeRangeDeclarationUserStatus.UNKNOWN]: 'UNKNOWN',
 };
 
+export type PlayAgeRangeDeclarationUserStatusValues =
+  (typeof PlayAgeRangeDeclarationUserStatus)[keyof typeof PlayAgeRangeDeclarationUserStatus];
+
 export interface PlayAgeRangeDeclarationResult {
   isEligible: boolean;
   installId?: string;
-  userStatus?: string;
+  userStatus?: PlayAgeRangeDeclarationUserStatusValues;
   error?: string;
   ageLower?: number;
   ageUpper?: number;
   mostRecentApprovalDate?: string; // ISO 8601 format (YYYY-MM-DD)
 }
 
+// https://developer.apple.com/documentation/declaredagerange/agerangeservice/agerangedeclaration#Determining-the-age-set-method
+export const AppleAgeRangeDeclarationUserStatus = {
+  checkedByOtherMethod: 'checkedByOtherMethod',
+  governmentIDChecked: 'governmentIDChecked',
+  guardianCheckedByOtherMethod: 'guardianCheckedByOtherMethod',
+  guardianDeclared: 'guardianDeclared',
+  guardianGovernmentIDChecked: 'guardianGovernmentIDChecked',
+  guardianPaymentChecked: 'guardianPaymentChecked',
+  paymentChecked: 'paymentChecked',
+  selfDeclared: 'selfDeclared',
+
+  // Library defined statuses
+  declined: 'declined', // Declined sharing age range
+  unknown: 'unknown', // Fallback value
+} as const;
+
+export type AppleAgeRangeDeclarationUserStatusValues =
+  (typeof AppleAgeRangeDeclarationUserStatus)[keyof typeof AppleAgeRangeDeclarationUserStatus];
+
 export interface DeclaredAgeRangeResult {
   isEligible: boolean;
-  status?: string;
+  status?: AppleAgeRangeDeclarationUserStatusValues;
   parentControls?: string;
   lowerBound?: number;
   upperBound?: number;


### PR DESCRIPTION
This PR simplifies the Android age mocking and makes it configurable from anywhere in the native code

Example:
```
// MainActivity.kt
import com.margelo.nitro.playagerangedeclaration.PlayAgeRangeDeclaration
import com.margelo.nitro.playagerangedeclaration.PlayAgeRangeMockConfig

override fun onCreate() {
      ....
      PlayAgeRangeDeclaration.setMockUser(
        PlayAgeRangeMockConfig(
          userStatus = 1,
          ageLower = 13,
          ageUpper = 16,
        )
      )
}
```


Notes to keep in mind before merging:
- I have only tested the code by modifying it directly in my `node_modules` folder
- I haven't ran the nitro build script and I don't know if my changes will cause any issues with it.
- I have not bridged any of this code. Hopefully someone experienced with nitro can pick that up at some point.